### PR TITLE
feat(ci): automate version releases with semantic-release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,6 +54,39 @@ jobs:
       with:
         input: test-output.log
 
+  semantic-release:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+
+    - name: Install semantic-release
+      run: |
+        npm install -g semantic-release@24 \
+          @semantic-release/commit-analyzer@13 \
+          @semantic-release/release-notes-generator@14 \
+          @semantic-release/changelog@6 \
+          @semantic-release/github@11 \
+          @semantic-release/git@10
+
+    - name: Run semantic-release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: npx semantic-release
+
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
@@ -61,19 +94,19 @@ jobs:
     - uses: actions/checkout@v4
       with:
           fetch-depth: 0
-    
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: '1.23.x'
-    
+
     - name: Import GPG key
       id: import_gpg
       uses: crazy-max/ghaction-import-gpg@v6
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.PASSPHRASE }}
-    
+
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:


### PR DESCRIPTION
## Summary
- Adds automated semantic-release job to GitHub Actions workflow
- Eliminates need for manual tag creation
- Automatically creates versions based on conventional commits

## Changes
- Added `semantic-release` job that runs after build/test pass on main branch
- Installs semantic-release and all configured plugins (@semantic-release/commit-analyzer, release-notes-generator, changelog, github, git)
- Automatically analyzes commits and creates version tags
- Existing GoReleaser job triggers automatically when tags are created

## How It Works
1. Push conventional commits to main (feat/fix/BREAKING CHANGE)
2. Build & test jobs run
3. semantic-release analyzes commits and creates tag
4. Tag push triggers GoReleaser for release artifacts

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] Merge PR and push conventional commit to main
- [ ] Confirm semantic-release creates tag automatically
- [ ] Verify GoReleaser triggers on new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)