### PR TITLE
docs: add CLAUDE.md, project docs, and Dijkstra badge

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "extraKnownMarketplaces": {
+    "miro-plugins": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/miroapp-dev/claude-marketplace.git"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "miro-dijkstra-plugin@miro-plugins": true
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git status:*)",
+      "Bash(git show:*)",
+      "Bash(git blame:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)"
+    ],
+    "deny": [
+      "Bash(sudo:*)",
+      "Bash(su :*)",
+      "Bash(rm -rf:*)",
+      "Bash(chmod:*)",
+      "Bash(chown:*)",
+      "Bash(dd :*)",
+      "Bash(mkfs:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(nc :*)",
+      "Bash(ncat:*)",
+      "Bash(git push --force:*)",
+      "Bash(git reset --hard:*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+---
+generated_by: structure repo kubecheck
+model: claude-opus-4-8
+reviewed: false
+last_source_sync: 44da450ec3ed559acf715c9f9886c50ef066b3cc
+---
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`kubecheck` (module path `github.com/ogarciacar/kubecheck`) is a Go **library** that makes a real, single-node Kubernetes cluster a first-class primitive inside Go tests. A test calls `kubecheck.NewCluster(...)`, gets a live `kind` cluster plus a standard `client-go` `*kubernetes.Clientset`, exercises real Kubernetes behaviour, and tears it down on `Destroy()`. There is no CLI, server, or deployed service — the consumable surface is a Go API.
+
+Note: the `README.md` still uses the module's former name `kluster1`; the module was rebranded to `kubecheck` (the 1.0.0 `BREAKING CHANGE`). Trust `go.mod` and `docs/` over the README.
+
+## Prerequisites
+
+- Go 1.23+
+- A **running Docker daemon** — the `kind` provider provisions clusters as Docker containers, and the test suite creates real clusters. No external cluster or `kubectl` is needed. The first run pulls a `kindest/node` image and may be slow.
+
+## Commands
+
+- `make test` — clears the test cache, then `go test -v ./... -cover`. Provisions and tears down real ephemeral clusters.
+- `make coverage` — runs tests writing `coverage.txt`.
+- `make covreport` — renders `coverage.txt` to `index.html`.
+- Run a single test: `go test -v ./kubecheck/ -run TestName` (clear cache first with `go clean -testcache` if re-running, since cluster tests are not cache-friendly).
+
+## Architecture
+
+A small layered module. The top-level orchestrator coordinates two pluggable collaborators behind **unexported interfaces**, plus a stateless helper package.
+
+- **`kubecheck/`** (package `kubecheck`) — the public orchestrator.
+  - `kubecheck.go`: the `K` struct and lifecycle API (`NewCluster`, `Destroy`, `GetClientset`, `GetKubeconfigPath`, `GetIngressPort`). Defines the two collaborator interfaces: `k8sRuntime` (Create/Delete) and `k8sKubeconfig` (CreateTempKubeconfig/DeleteTempKubeconfig).
+  - `models.go`: the `K8sVersion` value type and the single pinned release `K8sRelease_v1_30_10` (`1.30.10`).
+- **`kubecheck/compute/runtime/kindcluster/`** — concrete `k8sRuntime`. Wraps `sigs.k8s.io/kind`'s Docker provider, renders a single-control-plane Kind config from a template with a dynamic `hostPort`, and selects node image `kindest/node:v<version>`.
+- **`kubecheck/storage/persistence/tempkubeconfig/`** — concrete `k8sKubeconfig`. Creates a unique temp dir (`os.MkdirTemp`, `*-kubecheck` pattern), returns the kubeconfig path inside it, removes it on teardown.
+- **`sdk/`** — stateless helpers: `GetHostFreePort` (OS-assigned free TCP port) and `GenerateUniqueID` (8-char UUID prefix).
+
+**Cluster-creation flow:** `NewCluster` derives a name `k1-<uniqueID>` → temp kubeconfig dir created → runtime gets a free host port, renders the Kind config mapping that port, creates the cluster → REST config built from the kubeconfig via `clientcmd.BuildConfigFromFlags` → `*kubernetes.Clientset` constructed and returned in `*K`. `Destroy()` deletes the cluster then the temp dir.
+
+**Key invariant — Kubernetes version coherence:** the supported version is one pinned constant, and `client-go`/`k8s.io/api`/`apimachinery` in `go.mod` are pinned to the matching minor (v0.30.0). To bump the supported version: change the `K8sVersion` constant in `models.go`, align all `k8s.io/*` modules to the same minor, `go mod tidy`, and verify with `make test` against the new `kindest/node` image.
+
+## Conventions
+
+- **Conventional Commits are required** — versioning is fully automated by semantic-release. Commit type drives the release: `fix:` → patch, `feat:` → minor, `BREAKING CHANGE:`/`!` → major.
+- **Do not hand-edit `CHANGELOG.md` or create git tags manually** — the CI pipeline owns versioning. On push to `main`, semantic-release computes the version, updates the changelog, tags, and creates the GitHub release; GoReleaser runs with `builds: skip: true` (this is a library — no binaries are produced).
+- CI (`.github/workflows/go.yml`) gates every PR on `build` (`go mod tidy` + `go build -v ./...`) and `test` (via `gotestsum`); both must pass. There is no `CODEOWNERS`/`CONTRIBUTING.md`, so reviews are not auto-assigned.
+- Sharing a cluster across tests: create one in `TestMain`, store it in a package-level `*kubecheck.K`, and `Destroy()` in teardown (see `kubecheck/shared_cluster_test.go`).
+
+## Project documentation (`docs/`)
+
+Richer, task-oriented documentation lives under `docs/` — consult it before deep work:
+
+- `docs/purpose.md` — purpose, scope, and non-goals.
+- `docs/architecture.md` — components, data flow, design decisions, dependencies.
+- `docs/workflows.md` — shipping changes, version migrations, release/deploy procedure.
+- `docs/interfaces.md` — the public Go API surface and usage contracts.
+- `docs/operations.md` — local run, configuration/environment, CI runbook.
+- `docs/ownership.md` — ownership and escalation (best-effort; inferred).
+
+## Keeping docs fresh
+
+After source changes, run `/update-docs` in Claude Code, or see `.claude/skills/update-docs/SKILL.md`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # `kluster1`: Kubernetes TDD, Simplified.
 [![Go Version](https://img.shields.io/badge/Go-1.23+-blue)](https://golang.org/) [![Go Report Card](https://goreportcard.com/badge/github.com/ogarciacar/kluster1)](https://goreportcard.com/report/github.com/ogarciacar/kluster1)
+[![dijkstra 78%](https://img.shields.io/badge/dijkstra-78%25-ffd700?logo=miro)](https://github.com/miroapp-dev/miro-dijkstra)
 
 **Stop managing Kubernetes infrastructure, start testing your applications.**
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 # `kluster1`: Kubernetes TDD, Simplified.
-
-[![dijkstra 78%](https://img.shields.io/badge/dijkstra-78%25-ffd700?logo=miro)](https://github.com/miroapp-dev/miro-dijkstra)
-
-
 [![Go Version](https://img.shields.io/badge/Go-1.23+-blue)](https://golang.org/) [![Go Report Card](https://goreportcard.com/badge/github.com/ogarciacar/kluster1)](https://goreportcard.com/report/github.com/ogarciacar/kluster1)
 
 **Stop managing Kubernetes infrastructure, start testing your applications.**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # `kluster1`: Kubernetes TDD, Simplified.
 
+[![Static Badge](https://img.shields.io/badge/dijkstra-78%25-ffd700?logo=miro)](https://github.com/miroapp-dev/miro-dijkstra)
+
+
 [![Go Version](https://img.shields.io/badge/Go-1.23+-blue)](https://golang.org/) [![Go Report Card](https://goreportcard.com/badge/github.com/ogarciacar/kluster1)](https://goreportcard.com/report/github.com/ogarciacar/kluster1)
 
 **Stop managing Kubernetes infrastructure, start testing your applications.**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `kluster1`: Kubernetes TDD, Simplified.
 
-[![Static Badge](https://img.shields.io/badge/dijkstra-78%25-ffd700?logo=miro)](https://github.com/miroapp-dev/miro-dijkstra)
+[![dijkstra 78%](https://img.shields.io/badge/dijkstra-78%25-ffd700?logo=miro)](https://github.com/miroapp-dev/miro-dijkstra)
 
 
 [![Go Version](https://img.shields.io/badge/Go-1.23+-blue)](https://golang.org/) [![Go Report Card](https://goreportcard.com/badge/github.com/ogarciacar/kluster1)](https://goreportcard.com/report/github.com/ogarciacar/kluster1)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,43 @@
+---
+generated_by: structure repo kubecheck
+model: claude-opus-4-8
+reviewed: false
+title: kubecheck — Architecture & Dependencies
+area: architecture
+audience: [agent, human]
+tags: [architecture, components, data-flow, dependencies, kind]
+gold_for_tasks: [T3, T6]
+last_verified: 2026-06-11
+---
+# Architecture
+
+`kubecheck` is a small layered Go module. The top-level orchestrator coordinates two pluggable collaborators (a cluster runtime and a kubeconfig manager) behind interfaces, plus a stateless `sdk` of helpers.
+
+## Components (all paths verified against the tree)
+- **`kubecheck/` (package `kubecheck`)** — public orchestrator.
+  - `kubecheck.go`: the `K` struct and lifecycle API (`NewCluster`, `Destroy`, `GetClientset`, `GetKubeconfigPath`, `GetIngressPort`). Defines two collaborator interfaces — `k8sRuntime` (Create/Delete) and `k8sKubeconfig` (CreateTempKubeconfig/DeleteTempKubeconfig).
+  - `models.go`: `K8sVersion` value type and the pinned release `K8sRelease_v1_30_10` (`1.30.10`).
+- **`kubecheck/compute/runtime/kindcluster/` (package `kindcluster`)** — the concrete `k8sRuntime`. Wraps `sigs.k8s.io/kind`'s `cluster.Provider` (Docker provider), renders a single-control-plane Kind config from a template with a dynamic `hostPort`, and selects the node image `kindest/node:v<version>`.
+- **`kubecheck/storage/persistence/tempkubeconfig/` (package `tempkubeconfig`)** — the concrete `k8sKubeconfig`. Creates a unique temp directory (`os.MkdirTemp` with a `*-kubecheck` pattern), returns the `config` path inside it, and removes the directory on teardown.
+- **`sdk/` (package `sdk`)** — stateless helpers: `GetHostFreePort` (binds `tcp :0`, lets the OS assign a port) and `GenerateUniqueID` (first 8 chars of a UUID).
+
+## Data flow (cluster creation)
+1. `NewCluster(version)` builds a `kindcluster` runtime and a `tempkubeconfig` manager, and derives a cluster name `k1-<uniqueID>`.
+2. The kubeconfig manager creates a temp dir and returns the kubeconfig path.
+3. The runtime asks `sdk.GetHostFreePort()` for a port, renders the Kind config mapping that `hostPort`, and creates the cluster with the chosen node image and kubeconfig path.
+4. `NewCluster` builds REST config from the kubeconfig via `clientcmd.BuildConfigFromFlags` and constructs a `*kubernetes.Clientset`.
+5. The populated `K` (kubeconfig, name, runtime, clientset, ingress port, kubeconfig manager) is returned. `Destroy()` deletes the cluster, then the temp kubeconfig dir.
+
+## Key design decisions
+- **Interface-seamed collaborators** (`k8sRuntime`, `k8sKubeconfig`) keep the runtime and persistence pluggable and testable.
+- **Pinned Kubernetes version** as a typed value (`K8sVersion`) keeps client-go and node image in lockstep.
+- **Ephemeral, single-node** topology by construction.
+
+## Upstream dependencies (from `go.mod`, Go 1.23)
+- `sigs.k8s.io/kind` v0.27.0 — cluster provisioning (requires **Docker** at runtime; pulls `kindest/node` images).
+- `k8s.io/client-go`, `k8s.io/api`, `k8s.io/apimachinery` v0.30.0 — Kubernetes client and types.
+- `github.com/google/uuid` v1.6.0 — unique IDs.
+- `github.com/stretchr/testify` v1.10.0 — test assertions.
+Numerous transitive `// indirect` deps support the above; see `go.mod`/`go.sum` for the full set.
+
+Procedures for changing this design live in `workflows.md`; the consumer-facing surface is in `interfaces.md`.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,47 @@
+---
+generated_by: structure repo kubecheck
+model: claude-opus-4-8
+reviewed: false
+title: kubecheck — Public Interfaces & Contracts
+area: interfaces
+audience: [agent, human]
+tags: [api, public-api, entry-points, contracts, go-module]
+gold_for_tasks: [T5]
+last_verified: 2026-06-11
+---
+# Interfaces
+
+`kubecheck` exposes a Go library API only — there is no CLI, HTTP server, or event bus. Consumers import the packages below. Module path: `github.com/ogarciacar/kubecheck`.
+
+## Primary entry point — package `kubecheck` (`kubecheck/kubecheck.go`, `models.go`)
+
+**Construction**
+- `func NewCluster(k8sVersion K8sVersion) (*K, error)` — provisions a single-node cluster, builds a clientset, returns the handle `*K`. Logs progress (cluster name, kubeconfig path, ingress port). Requires Docker. Errors propagate from temp-dir creation, cluster create, or client build.
+
+**Type `K` methods (the test-facing contract)**
+- `func (k *K) GetClientset() *kubernetes.Clientset` — standard `client-go` clientset for the cluster.
+- `func (k *K) GetKubeconfigPath() string` — path to the cluster's temp kubeconfig.
+- `func (k *K) GetIngressPort() int` — host port mapped into the node for reaching workloads (e.g. `http://localhost:<port>/`).
+- `func (k *K) Destroy() error` — deletes the cluster and removes the temp kubeconfig directory. Intended for `defer`/teardown.
+
+**Version values (`models.go`)**
+- `type K8sVersion struct { ... }` with `func (k K8sVersion) String() string` → `v<release>` (e.g. `v1.30.10`).
+- `var K8sRelease_v1_30_10 K8sVersion` — the currently supported, pinned release passed to `NewCluster`.
+
+**Internal contracts (not for external implementation, but part of the design):** `k8sRuntime` (Create/Delete) and `k8sKubeconfig` (CreateTempKubeconfig/DeleteTempKubeconfig) are unexported interfaces in `kubecheck.go`; their implementations are described in `architecture.md`.
+
+## Helper package `sdk` (`sdk/free_port.go`, `sdk/unique_id.go`)
+- `func GetHostFreePort() (int, error)` — returns an OS-assigned free TCP port.
+- `func GenerateUniqueID() string` — 8-character unique id (UUID prefix).
+
+## Usage contract (from `kubecheck/quick_start_test.go`)
+```go
+k1, err := kubecheck.NewCluster(kubecheck.K8sRelease_v1_30_10)
+if err != nil { t.Fatalf("...") }
+defer k1.Destroy()
+clientset := k1.GetClientset()
+// ... exercise the real cluster via client-go ...
+```
+A common pattern (see `kubecheck/shared_cluster_test.go`) is to create one cluster in `TestMain`, share it across parallel tests via a package-level `*kubecheck.K`, and `Destroy()` in teardown.
+
+Packages under `compute/runtime/...` and `storage/persistence/...` are implementation detail and not part of the public contract.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,39 @@
+---
+generated_by: structure repo kubecheck
+model: claude-opus-4-8
+reviewed: false
+title: kubecheck — Operations, Config & Local Run
+area: operations
+audience: [agent, human]
+tags: [operations, config, env, local-dev, runbook, ci-secrets]
+gold_for_tasks: [T4, T8, T11]
+last_verified: 2026-06-11
+---
+# Operations
+
+This is a test-support library, not a deployed service. "Operations" here means running it locally, its configuration surface, and the CI runbook.
+
+## How to run it locally (T4)
+**Prerequisites:** Go 1.23+ and a running **Docker** daemon (the `kind` provider uses Docker). No external cluster or `kubectl` needed.
+
+Common commands (`Makefile`):
+- `make test` — `go clean -testcache` then `go test -v ./... -cover`. Provisions real ephemeral clusters; the suite manages create/teardown itself.
+- `make coverage` — runs tests writing `coverage.txt`.
+- `make covreport` — renders `coverage.txt` to `index.html`.
+
+To use it from your own project: `go get github.com/ogarciacar/kubecheck`, then call `kubecheck.NewCluster(...)` from a test (see `interfaces.md`). Each `NewCluster` call pulls/uses a `kindest/node` image and starts a Docker-backed node, so the first run may be slow and a working Docker context is mandatory.
+
+## Configuration & environment (T8)
+There is no config file. Behaviour is determined by code constants and a few runtime touchpoints:
+- **Kubernetes version** — set in code via `K8sRelease_v1_30_10` (`kubecheck/models.go`); not an env var.
+- **`KUBECONFIG`** — `kubecheck` does **not** read a `KUBECONFIG` from the environment; it generates its own temp kubeconfig under the OS temp dir (`os.MkdirTemp`, `*-kubecheck` pattern) and logs the path. Honour the OS temp-dir conventions (e.g. `TMPDIR`) if you need to relocate it.
+- **Host port** — assigned dynamically by the OS at runtime; retrieve with `GetIngressPort()`. Nothing to configure.
+- **CI secrets (config for the release pipeline only, names only):** `GITHUB_TOKEN`, `GPG_PRIVATE_KEY`, `PASSPHRASE`, consumed by `.github/workflows/go.yml`. Values are provided by GitHub Actions secrets; the workflow references them by name and `persist-credentials: false` is used on checkout. Do not inline secret values anywhere.
+
+## Runbook / on-call (T11)
+There is **no on-call rotation, monitoring, alerting, or production runbook** for this module, and none is documented in the repo — it ships no running service. The operational failure surface is local/CI test execution:
+- *Cluster create fails / hangs* → confirm Docker is running and the `kindest/node:v<version>` image is pullable; re-run `make test`.
+- *Port/HTTP checks fail* → the suite retries HTTP GETs; ensure no host firewall blocks the mapped port and that leftover containers from a crashed run are pruned (`Destroy()` normally cleans up).
+- *CI red* → inspect the `build`/`test` jobs in the Go workflow; release issues are governed by the pipeline in `workflows.md`.
+
+Escalation for any of the above is via the maintainer in `ownership.md`.

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -1,0 +1,29 @@
+---
+generated_by: structure repo kubecheck
+model: claude-opus-4-8
+reviewed: false
+title: kubecheck — Ownership & Escalation
+area: ownership
+audience: [agent, human]
+tags: [ownership, codeowners, reviewers, escalation]
+gold_for_tasks: [T12]
+last_verified: unknown
+---
+# Ownership
+
+## Status: largely undocumented
+The repository contains **no `CODEOWNERS` file, no `CONTRIBUTING.md`, no `MAINTAINERS` file, and no team/escalation documentation.** Ownership below is inferred from git history and GitHub metadata, not from a formal source of truth — treat it as best-effort (hence `last_verified: unknown`).
+
+## Who reviews PRs (T12)
+- No automated reviewer assignment exists (absence of `CODEOWNERS`), so GitHub does not auto-request reviews.
+- The module owner is the GitHub account **`ogarciacar`** (module path `github.com/ogarciacar/kubecheck`); recent commit authorship is **Orlando Jose Garcia Carmona**. Merged PRs (#34, #41, #42) flow through this single owner, who is the de-facto reviewer/approver.
+- Several changes were co-authored with an AI assistant (noted in `CHANGELOG.md` / commit trailers); this is an authoring aid, not a reviewer.
+- Branch protection / required-review settings are not visible in-repo; the CI gates in `.github/workflows/go.yml` (build + test) are the enforced merge bar. Whether human review is mandatory is not documented.
+
+## Escalation path
+With a single maintainer and no published rotation, escalation is: open a GitHub issue or PR on `ogarciacar/kubecheck` and tag the repository owner. There is no secondary owner or team alias defined in the repository.
+
+## Recommended follow-ups (to close the gap)
+- Add a `CODEOWNERS` file mapping `kubecheck/`, `sdk/`, and CI config to reviewers.
+- Add `CONTRIBUTING.md` documenting the review/merge expectations referenced in `workflows.md`.
+This file should be re-verified once any of the above lands.

--- a/docs/purpose.md
+++ b/docs/purpose.md
@@ -1,0 +1,36 @@
+---
+generated_by: structure repo kubecheck
+model: claude-opus-4-8
+reviewed: false
+title: kubecheck — Purpose & Scope
+area: purpose
+audience: [agent, human]
+tags: [purpose, scope, non-goals, tdd, kubernetes]
+gold_for_tasks: [T1, T2]
+last_verified: 2026-06-11
+---
+# Purpose
+
+`kubecheck` is a Go module (`github.com/ogarciacar/kubecheck`) that makes a real, single-node Kubernetes cluster a first-class primitive inside Go tests. Instead of pointing tests at an external, shared cluster, a test calls `kubecheck.NewCluster(...)`, receives a live cluster plus a `client-go` clientset, exercises real Kubernetes behaviour, and tears the cluster down when the test finishes.
+
+## What it does
+- Spins up an ephemeral, single-node cluster per call using `kind` (Kubernetes IN Docker), pinned to a known Kubernetes release.
+- Hands the test a standard `*kubernetes.Clientset` so existing `client-go` code works unchanged.
+- Allocates an OS-assigned free host port and maps it into the node so workloads under test are reachable from the host.
+- Manages a throwaway kubeconfig in a temp directory and cleans up both cluster and kubeconfig on `Destroy()`.
+
+## Strategy
+Shift Kubernetes from an external, shared testing dependency to an embedded test primitive that runs identically on a laptop and in CI. The promise is production-like feedback during development and CI without the coordination overhead, cost, and fragility of shared test clusters. The intended users are platform and DevEx engineers who own CI pipelines and want real system behaviour tested rather than mocked.
+
+## Scope
+- In scope: programmatic cluster lifecycle (create/destroy) from Go test code; exposing a clientset, kubeconfig path, and ingress port; small reusable test helpers (free-port discovery, unique-id generation).
+- Supported runtime today: a single pinned Kubernetes release (`K8sRelease_v1_30_10`) on a single-node `kind` cluster backed by Docker.
+
+## Non-goals
+- **Not** a production or long-lived cluster manager — clusters are ephemeral and single-node.
+- **Not** a manager of shared/external test clusters; eliminating that coordination is the whole point.
+- **Not** a replacement for `kubectl`, Helm, or a CI cluster-provisioning system in production environments.
+- **Not** a multi-node, HA, or cloud-provider cluster tool — topology is fixed to one control-plane node.
+- **Not** a general CLI; the surface is a Go API consumed from tests (see `interfaces.md`).
+
+For the component breakdown that delivers this, see `architecture.md`; for the public API, see `interfaces.md`.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,35 @@
+---
+generated_by: structure repo kubecheck
+model: claude-opus-4-8
+reviewed: false
+title: kubecheck — Change, Migration & Release Workflows
+area: workflows
+audience: [agent, human]
+tags: [contributing, release, semantic-release, ci, migrations, versioning]
+gold_for_tasks: [T7, T9, T10]
+last_verified: 2026-06-11
+---
+# Workflows
+
+## How to ship a safe change (T7)
+1. Branch from `main`. The repo has no `CONTRIBUTING.md`; the de-facto process is observable from CI and git history (PRs merged to `main`, e.g. #41, #42).
+2. Write/adjust tests. Tests provision real `kind` clusters, so **Docker must be running locally** (see `operations.md` for the run command).
+3. Run the suite locally before pushing: `make test` (`go test -v ./... -cover`).
+4. Open a PR targeting `main`. The **Go** workflow (`.github/workflows/go.yml`) runs three gates on every PR: `build` (`go mod tidy` + `go build -v ./...`) and `test` (`gotestsum ... -v ./...` with a test report). Both must pass.
+5. **Use Conventional Commits.** Versioning is fully automated by semantic-release (`commit-analyzer`), so commit type drives the release: `fix:` → patch, `feat:` → minor, `BREAKING CHANGE:`/`!` → major. The 1.0.0 release was triggered by a `BREAKING CHANGE` (kluster1 → kubecheck rename).
+6. Merge to `main` after review (see `ownership.md` for reviewers).
+
+## How architecture changes are done (T9)
+There is **no documented RFC/ADR or design-review process** in the repo. In practice, structural changes land as ordinary reviewed PRs to `main` under the same CI gates, and breaking ones are signalled through Conventional-Commit `BREAKING CHANGE` footers that force a major release and a `CHANGELOG.md` entry (the kluster1→kubecheck rebrand is the canonical example). Treat any need for a formal approval ceremony as currently undocumented.
+
+## "Schema" / version-compatibility migrations (T10)
+This module has **no database and no persistent schema**, so there are no schema migrations in the conventional sense. The analogous migration is keeping the supported Kubernetes contract coherent:
+- The supported release is a single pinned constant, `K8sRelease_v1_30_10` in `kubecheck/models.go`.
+- The runtime derives the node image as `kindest/node:v<release>` (`kindcluster.go`), and `client-go`/`k8s.io/api` are pinned in `go.mod` to the matching minor (v0.30.0).
+- To "migrate" to a new Kubernetes version: bump the `K8sVersion` constant, align the `k8s.io/*` module versions in `go.mod` to the same minor (prior commit `refactor(version): match client-go with the kubernetes api`), run `go mod tidy`, and verify with `make test` against the new `kindest/node` image. Ship as a `feat:`/`BREAKING CHANGE:` commit as appropriate.
+
+## Release & deploy procedure
+Releases are CI-driven, not manual:
+1. On push to `main`, the `semantic-release` job runs (after `build`+`test`) using `.releaserc.json` plugins: `commit-analyzer`, `release-notes-generator`, `changelog`, `github`, `git`. It computes the next version, updates `CHANGELOG.md`, commits, tags, and creates the GitHub release.
+2. The pushed tag triggers the `release` job: it imports a GPG key and runs **GoReleaser** (`.goreleaser.yaml`, `builds: skip: true` — no binaries; this is a library, so the "release" is the tagged module + GitHub release).
+Do not hand-edit `CHANGELOG.md` or create tags manually; let the pipeline own versioning. Required CI secrets are listed in `operations.md`.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with project guidance and architecture notes for Claude Code
- Adds six task-oriented docs under `docs/` (purpose, architecture, workflows, interfaces, operations, ownership)
- Adds Claude Code settings in `.claude/settings.json`
- Adds Dijkstra badge to `README.md`

## Test plan
- [ ] Verify CI passes (build + test jobs)
- [ ] Confirm `docs/` content matches current source architecture
- [ ] README badge renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)